### PR TITLE
Implemented support for installing `libcurl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Requirements
 Attributes
 ==========
 
+* `default['curl']['libcurl_packages']` - A list of libcurl packages to install.
+
 Usage
 =====
 
@@ -27,6 +29,11 @@ default
 -------
 
 Installs/Configures curl
+
+libcurl
+-------
+
+Install/Configure libcurl packages
 
 Testing
 =======

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,26 @@
+# encoding: UTF-8
+#
+# Cookbook Name:: curl
+# Recipe:: default
+#
+# Copyright 2014, John Dewey
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform_family']
+when 'debian'
+  default['curl']['libcurl_packages'] = %w(libcurl3 libcurl4-openssl-dev)
+when 'rhel'
+  default['curl']['libcurl_packages'] = %w(curl-devel)
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,13 @@ maintainer_email 'john@dewey.ws'
 license 'Apache 2.0'
 description 'Installs/Configures curl'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.1'
+version '2.0.0'
 
 recipe 'curl', 'Installs/Configures curl'
+recipe 'libcurl', 'Install/Configure libcurl packages'
 
-%w(centos debian ubuntu).each do |os|
-  supports os
-end
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'redhat'
+supports 'ubuntu'

--- a/recipes/libcurl.rb
+++ b/recipes/libcurl.rb
@@ -1,0 +1,25 @@
+# encoding: UTF-8
+#
+# Cookbook Name:: curl
+# Recipe:: libcurl
+#
+# Copyright 2014, John Dewey
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node['curl']['libcurl_packages'].each do |pkg|
+  package pkg do
+    action :upgrade
+  end
+end

--- a/spec/libcurl_debian_spec.rb
+++ b/spec/libcurl_debian_spec.rb
@@ -1,0 +1,16 @@
+# encoding: UTF-8
+
+require_relative 'spec_helper'
+
+describe 'curl::libcurl' do
+  let(:chef_run) do
+    ChefSpec::Runner.new(DEBIAN_OPTS)
+      .converge(described_recipe)
+  end
+
+  it 'installs packages' do
+    %w(libcurl3 libcurl4-openssl-dev).each do |pkg|
+      expect(chef_run).to upgrade_package pkg
+    end
+  end
+end

--- a/spec/libcurl_rhel_spec.rb
+++ b/spec/libcurl_rhel_spec.rb
@@ -1,0 +1,16 @@
+# encoding: UTF-8
+
+require_relative 'spec_helper'
+
+describe 'curl::libcurl' do
+  let(:chef_run) do
+    ChefSpec::Runner.new(RHEL_OPTS)
+      .converge(described_recipe)
+  end
+
+  it 'installs package' do
+    %w(curl-devel).each do |pkg|
+      expect(chef_run).to upgrade_package pkg
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,12 @@ require 'chef'
 require 'chefspec'
 require 'chefspec/berkshelf'
 require 'chefspec/deprecations'
+
+::RHEL_OPTS = {
+  platform: 'redhat',
+  version: '6.3'
+}
+DEBIAN_OPTS = {
+  platform: 'ubuntu',
+  version: '12.04'
+}


### PR DESCRIPTION
- Debian installs `libcurl3` and `libcurl4-openssl-dev`.
  Installing just `libcurl4-openssl-dev` would bring in
  `libcurl3`.  However, wanted others to know what my
  intentions were.
- RHEL installs `curl-devel`.  Not sure if this is the
  right package, but seems "right enough".

Fixes: #1
